### PR TITLE
feat(error-codes): Add codes to thrown errors

### DIFF
--- a/packages/core/src/util/EmdaerError.js
+++ b/packages/core/src/util/EmdaerError.js
@@ -1,0 +1,6 @@
+/* @flow */
+class EmdaerError extends Error {
+  code: string;
+}
+
+module.exports = EmdaerError;

--- a/packages/core/src/util/EmdaerError.js
+++ b/packages/core/src/util/EmdaerError.js
@@ -1,4 +1,10 @@
 /* @flow */
+
+/**
+ * @class
+ * A custom error class which has a `code` property that
+ * should align with emdaer errors defined in ../_errors.js
+ */
 class EmdaerError extends Error {
   code: string;
   constructor(code: string, ...args: any) {

--- a/packages/core/src/util/EmdaerError.js
+++ b/packages/core/src/util/EmdaerError.js
@@ -1,6 +1,14 @@
 /* @flow */
 class EmdaerError extends Error {
   code: string;
+  constructor(code: string, ...args: any) {
+    const [message, ...rest] = args;
+    super(message || code, ...rest);
+
+    Error.captureStackTrace(this, EmdaerError);
+
+    this.code = code;
+  }
 }
 
 module.exports = EmdaerError;

--- a/packages/core/src/util/EmdaerError.test.js
+++ b/packages/core/src/util/EmdaerError.test.js
@@ -1,0 +1,16 @@
+const EmdaerError = require('./EmdaerError');
+
+describe('EmdaerError', () => {
+  test('is an Error', () => {
+    const e = new EmdaerError('test-code', 'test message');
+    expect(e).toBeInstanceOf(Error);
+    expect(e.stack).toBeDefined();
+    expect(e.message).toBe('test message');
+    expect(e.code).toBe('test-code');
+  });
+
+  test('can default message', () => {
+    const e = new EmdaerError('test-code');
+    expect(e.message).toBe('test-code');
+  });
+});

--- a/packages/core/src/util/resolvePlugin.js
+++ b/packages/core/src/util/resolvePlugin.js
@@ -2,6 +2,7 @@
 
 import type { Plugin } from '../_types';
 
+const EmdaerError = require('./EmdaerError');
 const { NO_PLUGIN } = require('../_errors');
 
 /**
@@ -11,6 +12,8 @@ module.exports = function resolvePlugin(pluginName: string): Plugin {
   try {
     return require(pluginName);
   } catch (error) {
-    throw new Error(`${NO_PLUGIN}: ${pluginName}`);
+    const err = new EmdaerError(`${NO_PLUGIN}: ${pluginName}`);
+    err.code = NO_PLUGIN;
+    throw err;
   }
 };

--- a/packages/core/src/util/resolvePlugin.js
+++ b/packages/core/src/util/resolvePlugin.js
@@ -12,8 +12,7 @@ module.exports = function resolvePlugin(pluginName: string): Plugin {
   try {
     return require(pluginName);
   } catch (error) {
-    const err = new EmdaerError(`${NO_PLUGIN}: ${pluginName}`);
-    err.code = NO_PLUGIN;
+    const err = new EmdaerError(NO_PLUGIN, `${NO_PLUGIN}: ${pluginName}`);
     throw err;
   }
 };

--- a/packages/core/src/util/resolvePlugin.test.js
+++ b/packages/core/src/util/resolvePlugin.test.js
@@ -1,3 +1,4 @@
+const EmdaerError = require('./EmdaerError');
 const { NO_PLUGIN } = require('../_errors');
 
 const resolvePlugin = require('./resolvePlugin');
@@ -7,5 +8,8 @@ describe('resolvePlugin', () => {
     expect(() => {
       resolvePlugin('not-a-thing');
     }).toThrow(NO_PLUGIN);
+    expect(() => {
+      resolvePlugin('not-a-thing');
+    }).toThrow(EmdaerError);
   });
 });

--- a/packages/core/src/util/resolveTransform.js
+++ b/packages/core/src/util/resolveTransform.js
@@ -12,8 +12,10 @@ module.exports = function resolveTransform(transformName: string): Transform {
   try {
     return require(transformName);
   } catch (error) {
-    const err = new EmdaerError(`${NO_TRANSFORM}: ${transformName}`);
-    err.code = NO_TRANSFORM;
+    const err = new EmdaerError(
+      NO_TRANSFORM,
+      `${NO_TRANSFORM}: ${transformName}`
+    );
     throw err;
   }
 };

--- a/packages/core/src/util/resolveTransform.js
+++ b/packages/core/src/util/resolveTransform.js
@@ -2,6 +2,7 @@
 
 import type { Transform } from '../_types';
 
+const EmdaerError = require('./EmdaerError');
 const { NO_TRANSFORM } = require('../_errors');
 
 /**
@@ -11,6 +12,8 @@ module.exports = function resolveTransform(transformName: string): Transform {
   try {
     return require(transformName);
   } catch (error) {
-    throw new Error(`${NO_TRANSFORM}: ${transformName}`);
+    const err = new EmdaerError(`${NO_TRANSFORM}: ${transformName}`);
+    err.code = NO_TRANSFORM;
+    throw err;
   }
 };

--- a/packages/core/src/util/resolveTransform.test.js
+++ b/packages/core/src/util/resolveTransform.test.js
@@ -1,3 +1,4 @@
+const EmdaerError = require('./EmdaerError');
 const { NO_TRANSFORM } = require('../_errors');
 
 const resolveTransform = require('./resolveTransform');
@@ -7,5 +8,8 @@ describe('resolveTransform', () => {
     expect(() => {
       resolveTransform('not-a-thing');
     }).toThrow(NO_TRANSFORM);
+    expect(() => {
+      resolveTransform('not-a-thing');
+    }).toThrow(EmdaerError);
   });
 });


### PR DESCRIPTION
This adds codes to thrown errors so that modules that depend on emdaer
may programatically react to thrown errors without parsing messages.

This relates to #4.