### PR TITLE
feat(cli): report name of project when writing file

### DIFF
--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -19,15 +19,16 @@ module.exports = async function cli(args = process.argv) {
   if (!origins) {
     logger.warn(NO_MATCHING_FILES);
   } else {
+    const { name } = JSON.parse(await readFile('package.json', 'utf8'));
     await Promise.all(
       origins.map(origin =>
         (async () => {
           try {
-            const [, name, extension] = origin.match(
+            const [, fileName, fileExtension] = origin.match(
               /\.emdaer\/(.*)\.emdaer(\.md)/
             );
-            const destination = `${name}${extension}`;
-            logger.log(`Writing ${destination} 👌`);
+            const destination = `${fileName}${fileExtension}`;
+            logger.log(`Writing ${destination} for ${name} 👌`);
             await outputFile(
               destination,
               await emdaer(origin, (await readFile(origin)).toString())

--- a/packages/cli/src/index.test.js
+++ b/packages/cli/src/index.test.js
@@ -22,7 +22,8 @@ describe('@emdaer/cli', () => {
   });
   test('logs error when emdaer fails', async () => {
     glob.mockImplementation(() => ['./.emdaer/README.emdaer.md']);
-    fs.readFile.mockImplementation(() => {
+    fs.readFile.mockImplementationOnce(() => '{"name":"@emdaer/cli"}');
+    fs.readFile.mockImplementationOnce(() => {
       throw new Error();
     });
     const exitCode = await bin();
@@ -34,10 +35,13 @@ describe('@emdaer/cli', () => {
   });
   test('logs happy message on success', async () => {
     glob.mockImplementation(() => ['./.emdaer/README.emdaer.md']);
-    fs.readFile.mockImplementation(() => '');
+    fs.readFile.mockImplementationOnce(() => '{"name":"@emdaer/cli"}');
+    fs.readFile.mockImplementationOnce(() => '');
     fs.outputFile.mockImplementation(() => {});
     const exitCode = await bin();
-    expect(logger.log).toHaveBeenLastCalledWith('Writing README.md 👌');
+    expect(logger.log).toHaveBeenLastCalledWith(
+      'Writing README.md for @emdaer/cli 👌'
+    );
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
Because
```sh
emdaer: Writing README.md for @emdaer/plugin-details 👌
emdaer: Writing README.md for @emdaer/plugin-documentation 👌
emdaer: Writing README.md for @emdaer/core 👌
emdaer: Writing README.md for @emdaer/plugin-image 👌
emdaer: Writing README.md for @emdaer/plugin-link 👌
emdaer: Writing README.md for @emdaer/plugin-list-lerna-packages 👌
emdaer: Writing README.md for @emdaer/plugin-list 👌
emdaer: Writing README.md for @emdaer/plugin-shields 👌
emdaer: Writing README.md for @emdaer/plugin-table 👌
emdaer: Writing README.md for @emdaer/transform-github-emoji 👌
emdaer: Writing README.md for @emdaer/plugin-value-from-package 👌
emdaer: Writing README.md for @emdaer/transform-smartypants 👌
emdaer: Writing README.md for @emdaer/plugin-import 👌
emdaer: Writing README.md for @emdaer/cli 👌
emdaer: Writing README.md for @emdaer/plugin-license-reference 👌
```