### PR TITLE
ci: fetch unshallow for commitlint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ node_js: 8
 script:
   - make ci
 sudo: false
+before_install: git fetch --unshallow
 after_success: .travis/after_success.sh


### PR DESCRIPTION
Still getting this from travis

```
$ make ci
./node_modules/.bin/commitlint --from="master" --to="1c8fadc4f063c4f57139eedeef129ac57a26fa71"

/home/travis/build/emdaer/emdaer/node_modules/@commitlint/cli/lib/cli.js:67

		throw err;

		^


Error: Could not get git history from shallow clone.

Use git fetch --unshallow before linting.

Original issue: https://git.io/vyKMq

 Refer to https://git.io/vyKMv for details.

    at Object.<anonymous> (/home/travis/build/emdaer/emdaer/node_modules/@commitlint/core/lib/read.js:51:20)

    at <anonymous>

make: *** [commitlint-ci] Error 1



The command "make ci" exited with 2.
```