### PR TITLE
chore: sync versions and use --conventional-commits

### DIFF
--- a/.emdaer/.offline/plugin-contributors-details-github/contributors-data.json
+++ b/.emdaer/.offline/plugin-contributors-details-github/contributors-data.json
@@ -26,7 +26,7 @@
     "bio": null,
     "public_repos": 21,
     "public_gists": 1,
-    "followers": 32,
+    "followers": 33,
     "following": 15,
     "created_at": "2012-01-05T15:20:07Z",
     "updated_at": "2017-10-14T03:34:44Z"
@@ -58,7 +58,7 @@
     "bio": "I build multi-channel publishing systems and web applications at @fourkitchens.",
     "public_repos": 39,
     "public_gists": 1,
-    "followers": 18,
+    "followers": 19,
     "following": 56,
     "created_at": "2011-10-14T00:22:53Z",
     "updated_at": "2017-10-15T23:18:57Z"
@@ -90,7 +90,7 @@
     "bio": "Software architect with an interest in distributed systems and elegant solutions.",
     "public_repos": 73,
     "public_gists": 38,
-    "followers": 48,
+    "followers": 49,
     "following": 12,
     "created_at": "2010-10-20T16:40:28Z",
     "updated_at": "2017-10-10T15:36:14Z"
@@ -122,7 +122,7 @@
     "bio": null,
     "public_repos": 25,
     "public_gists": 2,
-    "followers": 15,
+    "followers": 16,
     "following": 10,
     "created_at": "2011-01-29T15:53:24Z",
     "updated_at": "2017-10-20T17:26:33Z"

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ lint:
 lint-staged:
 	./node_modules/.bin/lint-staged
 publish:
-	./node_modules/.bin/lerna publish
+	./node_modules/.bin/lerna publish --conventional-commits
 test:
 	./node_modules/.bin/jest
 type:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@emdaer/cli",
   "description": "emdaer CLI",
-  "version": "1.1.0",
+  "version": "1.2.1",
   "repository": "emdaer/emdaer",
   "homepage": "https://emdaer.me/",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@emdaer/core",
   "description": "emdaer core",
-  "version": "1.0.0",
+  "version": "1.2.1",
   "repository": "emdaer/emdaer",
   "homepage": "https://emdaer.me/",
   "keywords": [


### PR DESCRIPTION
Closes #3, Closes #22

`lerna publish --skip-npm` says all versions will update to the same version now. 