### PR TITLE
chore: Add PR/Issue templates and a note about AUTHORS file in CONTRIBUTING

### DIFF
--- a/.emdaer/CONTRIBUTING.emdaer.md
+++ b/.emdaer/CONTRIBUTING.emdaer.md
@@ -20,6 +20,10 @@
   - '@emdaer/plugin-import'
   - path: .emdaer/CONTRIBUTING/commits.md
 -->
+<!--emdaer-p
+  - '@emdaer/plugin-import'
+  - path: .emdaer/CONTRIBUTING/authors.md
+-->
 <!--emdaer-t
   - '@emdaer/transform-smartypants'
   - options: q

--- a/.emdaer/CONTRIBUTING/authors.md
+++ b/.emdaer/CONTRIBUTING/authors.md
@@ -1,0 +1,3 @@
+## AUTHORS file
+
+If you would like, when making your PR, add yourself to the AUTHORS file by appending `Name <githubusername>`. Doing so will add your name to contributor details list in the [Contributing](https://github.com/emdaer/emdaer#contributing) section.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,41 @@
+<!--
+Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!
+
+Please make sure that you are familiar with and follow the Code of Conduct for
+this project (found in the CODE_OF_CONDUCT.md file).
+
+Please fill out this template with all the relevant information so we can
+understand what's going on and fix the issue.
+-->
+
+- `emdaer` version:
+- `plugin-relevant-plugin-name` version (multiple if relevant):
+- `node` version:
+- `npm` (or `yarn`) version:
+
+Contents of your *.emdaer.md file:
+
+```md
+
+```
+
+What you did:
+
+
+
+What happened:
+
+<!-- Please provide the full error message/screenshots/anything -->
+
+Reproduction repository:
+
+<!--
+If possible, please create a repository that reproduces the issue with the
+minimal amount of code possible.
+-->
+
+Problem description:
+
+
+
+Suggested solution:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--
+Thanks for your interest in the project. We appreciate bugs filed and PRs submitted!
+
+Please make sure that you are familiar with and follow the Code of Conduct for
+this project (found in the CODE_OF_CONDUCT.md file).
+
+Also, please make sure you're familiar with and follow the instructions in the
+contributing guidelines (found in the CONTRIBUTING.md file).
+
+Please fill out the information below to expedite the review and (hopefully)
+merge of your pull request!
+-->
+
+<!-- What changes are being made? (What feature/bug is being fixed here?) -->
+**What**:
+
+<!-- Why are these changes necessary? -->
+**Why**:
+
+<!-- How were these changes implemented? -->
+**How**:
+
+<!-- Have you done all of these things?  -->
+**Checklist**:
+<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
+<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
+- [ ] Documentation
+- [ ] Tests
+- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
+- [ ] Added myself to AUTHORS <!-- this is optional, see the contributing guidelines for instructions -->
+
+<!-- Feel free to add additional comments -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,4 +74,8 @@ fix(plugin-image): Add more cat pics
 Closes #123, Closes #456
 ```
 
+## AUTHORS file
+
+If you would like, when making your PR, add yourself to the AUTHORS file by appending `Name <githubusername>`. Doing so will add your name to contributor details list in the [Contributing](https://github.com/emdaer/emdaer#contributing) section.
+
 


### PR DESCRIPTION
Closes #28

Obviously I'm open to ideas on this, but here's a first pass at these templates. Adapted from https://github.com/kentcdodds/kcd-scripts/tree/master/.github who manages > 100 of OSS projects, so they should be fairly tried and true.. 🤷‍♂️ 